### PR TITLE
Script test avec gecode

### DIFF
--- a/scripts/solve_sgp_gecode
+++ b/scripts/solve_sgp_gecode
@@ -1,0 +1,14 @@
+#!/bin/bash
+parent_path=$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)
+cd "$parent_path"
+FILES=../data/SGP/*
+model=../models/SGP/$1
+for f in $FILES
+do
+datanameext=$(basename "$f")
+dataname="${datanameext%.*}"
+minizinc --solver Gecode -O0 --random-seed 0 --time-limit 60000 --output-time --output-to-file sgp_gecode_O0_$dataname.txt $model $f
+minizinc --solver Gecode -O1 --random-seed 0 --time-limit 60000 --output-time --output-to-file sgp_gecode_O1_$dataname.txt $model $f
+minizinc --solver Gecode -O2 --random-seed 0 --time-limit 60000 --output-time --output-to-file sgp_gecode_O2_$dataname.txt $model $f
+done
+


### PR DESCRIPTION
Utilisation : `./scripts/solve_sgp_gecode model_set.mzn`

Le paramètre correspond au modèle SGP à tester.
Le script génère des `.txt` dont il faudra ensuite extraire les temps.

Cette PR est la première étape pour fermer #13 